### PR TITLE
Update Intstab Manual

### DIFF
--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -144,7 +144,23 @@ The RedPitaya lockbox is mounted in a 19-inch Fischer rack mount unit with our s
 \section{Setting up the software}
 
 \index{PyRPL}\marginlabel{Install PyRPL} 
-The RedPitaya is operated with the Python software package PyRPL. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file)
+The RedPitaya is operated with the Python software package PyRPL. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. The whole process is outdated, so to begin, an auxiliary environment is created. Some of the packages used require older versions of Python and Anaconda, starting with Python version 3.11 and Anaconda-Navigator 2.4.0 is recommended. To create the correct environment, run
+
+\begin{tcolorbox}
+	\begin{verbatim}
+		conda create -n pyrpl python=3.9 numpy=1.19
+		  pyqtgraph=0.12 pandas=1.3 scipy paramiko nose pip 
+		  pyqt qtpy=1.9.0 pyyaml ipywidgets notebook
+		conda activate pyrpl
+		pip uninstall pyopenssl cryptography
+		pip install pyopenssl==22.0.0 cryptography==36.0.2
+		pip install quamash
+		pip install scp
+	\end{verbatim}
+\end{tcolorbox}
+
+
+Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file)
 
 \begin{tcolorbox}
 	\begin{verbatim}

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -193,7 +193,7 @@ Clone or download the branch 'external\_pid\_pause' from \href{https://github.co
 \end{tcolorbox}
 
 It might be necessary to install certain Microsoft Visual Studio C++ tools in order to install the packages. \\
-\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the sample and hold feature (see Section ~\ref{sec:pyrpl_settings})  is not used, consider installing the 'master' branch in a new environment. The environment created with the instructions above only works for the  'external\_pid\_pause' branch. 
+\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the sample and hold feature (see Section ~\ref{sec:pyrpl_settings}) is not used, consider installing the 'master' branch in a new environment. The environment created with the instructions above only works for the  'external\_pid\_pause' branch. 
 
 \textbf{Known issues:}
 \begin{itemize}

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -167,7 +167,7 @@ Note that the support for Python 3.9 ends in 2025. Activate the environment via
 	\end{verbatim}
 \end{tcolorbox}
 
-Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file) 
+Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file).
 
 \begin{tcolorbox}
 	\begin{verbatim}

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -144,7 +144,7 @@ The RedPitaya lockbox is mounted in a 19-inch Fischer rack mount unit with our s
 \section{Setting up the software}
 
 \index{PyRPL}\marginlabel{Install PyRPL} 
-The RedPitaya is operated with the Python software package PyRPL. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. As the PyRPL branch used is not longer maintained, the dependencies clash with the latest version of Python and the environment setup process is outdated. Therefore, to begin, an auxiliary environment is created. Starting with Python version 3.11 and Anaconda Navigator 2.4.0 is recommended. To create the correct environment, run
+The RedPitaya is operated with the Python software package \href{https://github.com/pyrpl-fpga/pyrpl}{PyRPL}. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. As the \href{https://github.com/pyrpl-fpga/pyrpl/tree/external_pid_pause}{external\_pid\_pause PyRPL branch} used is not longer maintained, the dependencies clash with the latest version of Python and the environment setup process is outdated. Therefore, to begin, an auxiliary environment is created. Starting with Python version 3.11 or higher installed on the system and Anaconda Navigator 2.4.0 is recommended. To create a compatible Python 3.9 auxiliary environment, run
 
 \begin{tcolorbox}
 	\begin{verbatim}

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -23,10 +23,10 @@
 \DeclareRobustCommand\cs[1]{\texttt{\char`\\#1}}
 
 \title{RedPitaya IntStab -- Manual\\
-	\textit{\normalsize{Latest board revision 1.5.1}}}
-\author{Tilman Preuschoff}
+	\textit{\normalsize{Latest board revision 1.5.2}}}
+\author{Tilman Preuschoff\\Jan Henning}
 
-\date{Last modified: 03.07.2023}
+\date{Last modified: 28.10.2025}
 \emergencystretch1em  % F"ur TeX <3.0 auskommentieren!
 
 
@@ -193,7 +193,7 @@ Clone or download the branch 'external\_pid\_pause' from \href{https://github.co
 \end{tcolorbox}
 
 It might be necessary to install certain Microsoft Visual Studio C++ tools in order to install the packages. \\
-\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the sample and hold feature (see Section \ref{sec:pyrpl_settings})  is not used, consider installing the 'master' branch in a new environment. The environment created with the instructions above only works for the  'external\_pid\_pause' branch. 
+\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the sample and hold feature (see Section ~\ref{sec:pyrpl_settings})  is not used, consider installing the 'master' branch in a new environment. The environment created with the instructions above only works for the  'external\_pid\_pause' branch. 
 
 \textbf{Known issues:}
 \begin{itemize}
@@ -350,7 +350,7 @@ The RedPitaya ADCs have considerable offsets and gain errors. The STEMlab softwa
 Determine the maximal (amplified) photodiode level using the 'PD Mon' output. Deactivate the PI and set the respective output to '\SI{1}{\volt}' (i.e. \SI{2}{\volt}) using the 'asg' module. Increase the 'gain' using the DIP switches if the value is below \SI{1}{\volt}. If possible, increase the power at the photodiode instead of increasing the gain. 
 
 \textbf{Note:}
-If the external loop gain is changed the PI parameters must be adapted (see Section \ref{sec:app_note} for details).
+If the external loop gain is changed the PI parameters must be adapted (see Section ~\ref{sec:app_note} for details).
 
 \index{I-gain}\marginlabel{I-gain}
 Choose a setpoint of approximately \SI{50}{\percent} of the maximal photodiode voltage. Set the P-gain to zero and increase the I-gain until the system start to oscillate. Use half of this I-gain as a starting point.

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -144,11 +144,11 @@ The RedPitaya lockbox is mounted in a 19-inch Fischer rack mount unit with our s
 \section{Setting up the software}
 
 \index{PyRPL}\marginlabel{Install PyRPL} 
-The RedPitaya is operated with the Python software package PyRPL. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. The whole process is outdated, so to begin, an auxiliary environment is created. Some of the packages used require older versions of Python and Anaconda, starting with Python version 3.11 and Anaconda-Navigator 2.4.0 is recommended. To create the correct environment, run
+The RedPitaya is operated with the Python software package PyRPL. You need a proper Python installation in order to run the software. For Windows OS, use \href{https://www.anaconda.com/}{Anaconda Python}. Create a virtual environment for PyRPL. As the PyRPL branch used is not longer maintained, the dependencies clash with the latest version of Python and the environment setup process is outdated. Therefore, to begin, an auxiliary environment is created. Starting with Python version 3.11 and Anaconda Navigator 2.4.0 is recommended. To create the correct environment, run
 
 \begin{tcolorbox}
 	\begin{verbatim}
-		conda create -n pyrpl python=3.9 numpy=1.19
+		conda create -n aux-env python=3.9 numpy=1.19
 		  pyqtgraph=0.12 pandas=1.3 scipy paramiko nose pip 
 		  pyqt qtpy=1.9.0 pyyaml ipywidgets notebook
 		conda activate pyrpl
@@ -159,8 +159,15 @@ The RedPitaya is operated with the Python software package PyRPL. You need a pro
 	\end{verbatim}
 \end{tcolorbox}
 
+Note that the support for Python 3.9 ends in 2025. Activate the environment via
 
-Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file)
+\begin{tcolorbox}
+	\begin{verbatim}
+		conda activate aux-env
+	\end{verbatim}
+\end{tcolorbox}
+
+Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl} and run (in the directory of the file) 
 
 \begin{tcolorbox}
 	\begin{verbatim}
@@ -168,16 +175,15 @@ Get \textit{pyrpl-env.yaml} from \href{https://github.com/TU-Darmstadt-APQ/RedPi
 	\end{verbatim}
 \end{tcolorbox}
 
-\textbf{Note:}  PyRPL is not compatible with the latest python and numpy version.
+\textbf{Note:}  PyRPL is not compatible with the latest Python and numpy version.
 
-Activate the environment via
 
+Activate the environment via 
 \begin{tcolorbox}
 	\begin{verbatim}
 		conda activate pyrpl-env
 	\end{verbatim}
 \end{tcolorbox}
-
 Clone or download the branch 'external\_pid\_pause' from \href{https://github.com/lneuhaus/pyrpl/tree/external_pid_pause}{https://github.com/ lneuhaus/pyrpl/tree/external\_pid\_pause}. In the directory of the source files, run:
 
 \begin{tcolorbox}
@@ -186,7 +192,8 @@ Clone or download the branch 'external\_pid\_pause' from \href{https://github.co
 	\end{verbatim}
 \end{tcolorbox}
 
-\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the installation does not work correctly and the sample and hold feature is not used, try installing the 'master' branch in a new environment.
+It might be necessary to install certain Microsoft Visual Studio C++ tools in order to install the packages. \\
+\textbf{Note:} The branch 'external\_pid\_pause' is not the latest stable version of PyRPL. It will not be updated. If the sample and hold feature (see Section \ref{sec:pyrpl_settings})  is not used, consider installing the 'master' branch in a new environment. The environment created with the instructions above only works for the  'external\_pid\_pause' branch. 
 
 \textbf{Known issues:}
 \begin{itemize}
@@ -228,7 +235,7 @@ Connect to the RedPitaya using a SSH terminal (e.g. \href{https://www.putty.org/
 Get the PyRPL example configuration file \textit{example\_intstab.yml} from \href{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/master/pyrpl}{https://github.com/TU-Darmstadt-APQ/RedPitaya-IntStab/tree/ master/pyrpl}. Copy \textit{example\_intstab.yml} to \textit{$\backslash$pyrpl\_user\_dir$\backslash$config}. Rename the configuration file according to your application, open it with a text editor, and set the RedPitaya's IP (redpitaya>hostname:), password  (redpitaya>password:) and name of the application (pyrpl>name:). The default location of the \textit{pyrpl\_user\_dir} is \textit{C:$\backslash$Users$\backslash$USER}.
 
 \index{Run PyRPL}\marginlabel{Run PyRPL}
-After configuration, PyRPL can be started by activating the virtual environment and loading the configuration file (in a python terminal):
+After configuration, PyRPL can be started by activating the virtual environment and loading the configuration file (in a Python terminal):
 
 \begin{tcolorbox}
 	\begin{verbatim}
@@ -318,13 +325,13 @@ The pre configured example uses the 'pid' module to implement two independent PI
 
 
 
-\subsection{PyRPL settings}
+\subsection{PyRPL settings} \label{sec:pyrpl_settings}
 
 \index{Input filters}\marginlabel{Input filters}
 PyRPL allows to set four digital filters as input filters for the PI. Use this feature if the bandwidth of the photodetector is much larger than the control bandwidth.
 
 \index{Sample and hold}\marginlabel{Sample and hold}
-In the 'pid' module, set 'pause\_gains' to 'pi' if the sample and hold feature is used. The sample and hold feature can be activated manually by activating the 'paused' checkbox. Note, that the features are only available if the branch 'external\_pid\_pause' is installed.
+The achievable transient times are limited by the bandwidth of the control loop. For applications that require control of the light fields on shorter time scales, such as short light pulses,the sample and hold featurecan be used. In order to do so, set 'pause\_gains' to 'pi' in the 'pid' module. The sample and hold feature can be activated manually by ticking the 'paused' checkbox. Note, that the features are only available if the branch 'external\_pid\_pause' is installed.
 
 \begin{figure}[H]
 	\includegraphics[width=\textwidth]{fig/sample_and_hold_P.png}\\
@@ -343,7 +350,7 @@ The RedPitaya ADCs have considerable offsets and gain errors. The STEMlab softwa
 Determine the maximal (amplified) photodiode level using the 'PD Mon' output. Deactivate the PI and set the respective output to '\SI{1}{\volt}' (i.e. \SI{2}{\volt}) using the 'asg' module. Increase the 'gain' using the DIP switches if the value is below \SI{1}{\volt}. If possible, increase the power at the photodiode instead of increasing the gain. 
 
 \textbf{Note:}
-If the external loop gain is changed the PI parameters must be adapted (see Section~\ref{sec:app_note} for details).
+If the external loop gain is changed the PI parameters must be adapted (see Section \ref{sec:app_note} for details).
 
 \index{I-gain}\marginlabel{I-gain}
 Choose a setpoint of approximately \SI{50}{\percent} of the maximal photodiode voltage. Set the P-gain to zero and increase the I-gain until the system start to oscillate. Use half of this I-gain as a starting point.

--- a/manual/manual.tex
+++ b/manual/manual.tex
@@ -331,7 +331,7 @@ The pre configured example uses the 'pid' module to implement two independent PI
 PyRPL allows to set four digital filters as input filters for the PI. Use this feature if the bandwidth of the photodetector is much larger than the control bandwidth.
 
 \index{Sample and hold}\marginlabel{Sample and hold}
-The achievable transient times are limited by the bandwidth of the control loop. For applications that require control of the light fields on shorter time scales, such as short light pulses,the sample and hold featurecan be used. In order to do so, set 'pause\_gains' to 'pi' in the 'pid' module. The sample and hold feature can be activated manually by ticking the 'paused' checkbox. Note, that the features are only available if the branch 'external\_pid\_pause' is installed.
+The achievable transient times are limited by the bandwidth of the control loop. For applications that require control of the light fields on shorter time scales, such as short light pulses, the sample and hold feature can be used. In order to do so, set 'pause\_gains' to 'pi' in the 'pid' module. The sample and hold feature can be activated manually by ticking the 'paused' checkbox. Note, that the features are only available if the branch 'external\_pid\_pause' is installed.
 
 \begin{figure}[H]
 	\includegraphics[width=\textwidth]{fig/sample_and_hold_P.png}\\


### PR DESCRIPTION
The setup process using a setup.py file is outdated and certain dependencies clash when following the setup instructions in the manual. The new set of instructions uses an auxiliary environment and Python 3.9 in order for the setup to work. Note that the setup only works for the custom external_pid_pause branch of PyRPL that offers shorter transient times.